### PR TITLE
fix: v1 demo link

### DIFF
--- a/index.html
+++ b/index.html
@@ -216,7 +216,7 @@
                 color="white"
                 text-color="black"
                 type="a"
-                href="https://v1.lnbits.com"
+                href="https://demo.lnbits.com"
                 label="Demo"
                 class="q-ml-sm"
                 size="lg"


### PR DESCRIPTION
Point to demo.lnbits.com instead of v1.lnbits.com